### PR TITLE
Fixed typo in readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ AngularJS directive to download an svg element as an SVG file.
 
 ## Usage
 1. `bower install Hypercubed/angular-downloadsvg-directive`
-2. Include the `FileSaver.js` script into your app.  By default should be at `bower_components/FileSaver/FileSaver.svg`.
+2. Include the `FileSaver.js` script into your app.  By default should be at `bower_components/FileSaver/FileSaver.js`.
 3. Include the `angular-downloadsvg-directive.js` into your app.  By default should be at `bower_components/angular-downloadsvg-directive/angular-downloadsvg-directive.js`.
 4. Add `hc.downloader` as a module dependency to your app.
 


### PR DESCRIPTION
Changed reference to filename in line 6 from `bower_components/FileSaver/FileSaver.js` to `bower_components/FileSaver/FileSaver.svg`.
