### PR TITLE
Bugfix for #3: Include 'points' in whitelist to enable polygons

### DIFF
--- a/angular-downloadsvg-directive.js
+++ b/angular-downloadsvg-directive.js
@@ -93,7 +93,8 @@
 		'maskUnits',
 		'transform',
 		'viewBox','version',											// Container
-		'preserveAspectRatio','xmlns'
+		'preserveAspectRatio','xmlns',
+		'points'				// Polygons
 	];
 
 	function copyStyles(target, source) {


### PR DESCRIPTION
Added 'points' to the whitelist so polygons are not longer broken.